### PR TITLE
Pin json-schema package to current latest version 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "css-what": "^5.0.1",
     "url-parse": "^1.5.2",
     "set-value": "4.0.1",
-    "ansi-regex": "5.0.1"
+    "ansi-regex": "5.0.1",
+    "json-schema": "0.4.0"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Version 0.3.0 has vulnerabilities and is failing pipeline dependency check