### PR TITLE
Add json-schema:0.2.3 suppression

### DIFF
--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -19,4 +19,14 @@
    <packageUrl regex="true">^pkg:npm/ansi\-html@.*$</packageUrl>
    <vulnerabilityName>1002522</vulnerabilityName>
 </suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: json-schema:0.2.3
+   json-schema is vulnerable to Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
+   CVE-2021-3918
+   ]]>
+   </notes>
+   <packageUrl regex="true">^pkg:npm/json\-schema@0\.2\.3$</packageUrl>
+   <vulnerabilityName>1006724</vulnerabilityName>
+</suppress>
 </suppressions>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -17,6 +17,10 @@
    For now there is no patch available for this vulnerability.
    ]]></notes>
    <packageUrl regex="true">^pkg:npm/ansi\-html@.*$</packageUrl>
+   <!-- 
+      this vulnerability ID needed for build agents HTFSPRDUAG01-Melanie-A01 + HTFSPRDUAG02-Melanie-A01 
+      because at the time of writing their vulnerability database is out-of-date
+   -->
    <vulnerabilityName>1002522</vulnerabilityName>
 </suppress>
 <suppress>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -17,6 +17,15 @@
    For now there is no patch available for this vulnerability.
    ]]></notes>
    <packageUrl regex="true">^pkg:npm/ansi\-html@.*$</packageUrl>
+   <vulnerabilityName>1002522</vulnerabilityName>
+</suppress>
+<suppress>
+   <notes><![CDATA[
+   file name: ansi-html:0.0.7
+   Vunerability is if an attacker provides a malicious string, it will get stuck processing the input for an extremely long time.
+   For now there is no patch available for this vulnerability.
+   ]]></notes>
+   <packageUrl regex="true">^pkg:npm/ansi\-html@.*$</packageUrl>
    <vulnerabilityName>1005059</vulnerabilityName>
 </suppress>
 <suppress>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -17,10 +17,6 @@
    For now there is no patch available for this vulnerability.
    ]]></notes>
    <packageUrl regex="true">^pkg:npm/ansi\-html@.*$</packageUrl>
-   <!-- 
-      this vulnerability ID needed for build agents HTFSPRDUAG01-Melanie-A01 + HTFSPRDUAG02-Melanie-A01 
-      because at the time of writing their vulnerability database is out-of-date
-   -->
    <vulnerabilityName>1002522</vulnerabilityName>
 </suppress>
 <suppress>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -17,7 +17,7 @@
    For now there is no patch available for this vulnerability.
    ]]></notes>
    <packageUrl regex="true">^pkg:npm/ansi\-html@.*$</packageUrl>
-   <vulnerabilityName>1002522</vulnerabilityName>
+   <vulnerabilityName>1005059</vulnerabilityName>
 </suppress>
 <suppress>
    <notes><![CDATA[

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -33,6 +33,8 @@
    file name: json-schema:0.2.3
    json-schema is vulnerable to Improperly Controlled Modification of Object Prototype Attributes ('Prototype Pollution')
    CVE-2021-3918
+   json-schema:0.2.3 is a dev dependency needed by "@angular/cli". It is not included in or used by our production code. On this 
+   basis it was deemed acceptable to suppress the vulnerability. 
    ]]>
    </notes>
    <packageUrl regex="true">^pkg:npm/json\-schema@0\.2\.3$</packageUrl>

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "css-what": "^5.0.1",
     "url-parse": "^1.5.2",
     "set-value": "4.0.1",
-    "ansi-regex": "5.0.1",
-    "json-schema": "0.4.0"
+    "ansi-regex": "5.0.1"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Please be aware our pipeline dependency checker is behaving different depending on which build agent it runs.

 *HTFSPRDUAG01-Melanie-A01* and *HTFSPRDUAG02-Melanie-A01* have the following behaviour:
- The ansi-html:0.0.7 suppression must be _NPM-1002522_ (please note this suppression already exists)
- The json-schema:0.2.3 vulnerability is not reported

Build agent *HTFSPRDUAG03-Melanie-A01* has the following behaviour:
- The ansi-html:0.0.7 suppression must be _NPM-1005059_ (which I have added in this PR)
- The json-schema:0.2.3 vulnerability is reported (and is suppressed in this PR)

