### PR TITLE
ABZ fix functional tests in main

### DIFF
--- a/Tests/FunctionalTests/fss-search-query.spec.ts
+++ b/Tests/FunctionalTests/fss-search-query.spec.ts
@@ -136,7 +136,7 @@ describe('Test Search Query Scenario On Search Page', () => {
     await page.click(pageObjectsConfig.chooseFileDownloadSelector);
 
     // Click on download button
-    await page.click(pageObjectsConfig.fileDownloadButton);
+    await page.click(pageObjectsConfig.fileDownloadButton, {force: true});
 
     // Get the file downloaded status
     const fileDownloadStatus = await page.getAttribute(pageObjectsConfig.fileDownloadButtonStatus, "class");

--- a/Tests/FunctionalTests/fss-simplified-search-home.spec.ts
+++ b/Tests/FunctionalTests/fss-simplified-search-home.spec.ts
@@ -43,7 +43,7 @@ describe('Test Search Attribute Scenario On Simplified Search Page', () => {
   it('Verify user clicks on "Advanced Search" link navigates to Advanced Search page', async () => {
     await page.click(pageObjectsConfig.simplifiedSearchLinkSelector);
     await page.waitForSelector(pageObjectsConfig.advancedSearchLinkSelector);
-    await page.click(pageObjectsConfig.advancedSearchLinkSelector);
+    await page.click(pageObjectsConfig.advancedSearchLinkSelector, {force: true});
     await page.waitForSelector(pageObjectsConfig.advancedSearchAddLineSelector);
     await page.click(pageObjectsConfig.advancedSearchAddLineSelector);
     await page.waitForSelector(pageObjectsConfig.advancedSearchTableSelector);   

--- a/Tests/FunctionalTests/fss-simplified-search-results.spec.ts
+++ b/Tests/FunctionalTests/fss-simplified-search-results.spec.ts
@@ -88,7 +88,7 @@ describe('Test Search Result Scenario On Simplified Search Page', () => {
      await page.click(pageObjectsConfig.chooseFileDownloadSelector);
   
      //Click on download button
-     await page.click(pageObjectsConfig.fileDownloadButton);
+     await page.click(pageObjectsConfig.fileDownloadButton, {force: true});
  
      //Get the file downloaded status
      const fileDownloadStatus=await page.getAttribute(pageObjectsConfig.fileDownloadButtonStatus,"class");


### PR DESCRIPTION
Force click action for elements that do not directly handle click event. I'm guessing that a behavioural change to a dependency (possibly Playwright) has made this change necessary.