### PR TITLE
Abzu 69881 - add retention policy for live deployments

### DIFF
--- a/Deployment/add-lease.ps1
+++ b/Deployment/add-lease.ps1
@@ -1,0 +1,29 @@
+Param(
+    [Parameter(mandatory=$true)][int]$daysValid,
+    [Parameter(mandatory=$true)][string]$accessToken,
+    [Parameter(mandatory=$true)][int]$definitionId,
+    [Parameter(mandatory=$true)][string]$ownerId,
+    [Parameter(mandatory=$true)][int]$buildId,
+    [Parameter(mandatory=$true)][string]$collectionUri,
+    [Parameter(mandatory=$true)][string]$teamProject
+)
+
+try{
+    $contentType = "application/json";
+    $headers = @{ Authorization = $accessToken };
+    $rawRequest = @{ daysValid = $daysValid; definitionId = $definitionId; ownerId = $ownerId; protectPipeline = $false; runId = $buildId };
+    $request = ConvertTo-Json @($rawRequest);
+    $uri = "$collectionUri$teamProject/_apis/build/retention/leases?api-version=7.0";
+
+    Write-Host $request
+    Write-Host $uri
+
+    Invoke-RestMethod -uri $uri -method POST -Headers $headers -ContentType $contentType -Body $request;
+
+    Write-Host "Pipeline will be retained for $daysValid days"
+}
+catch{
+   Write-Host "##vso[task.LogIssue type=warning;]Pipeline retention failed."
+   Write-Host $_
+   Write-Host "##vso[task.complete result=SucceededWithIssues;]"
+}

--- a/Deployment/templates/retain-pipeline.yml
+++ b/Deployment/templates/retain-pipeline.yml
@@ -1,0 +1,14 @@
+steps:
+  - task: PowerShell@2
+    condition: and(succeeded(), not(canceled()))
+    displayName: Retain Live Release
+    inputs:
+      targetType: filePath
+      filePath: "$(Build.SourcesDirectory)/Deployment/add-lease.ps1"
+      arguments: "-daysValid 365
+                  -accessToken 'Bearer $(System.AccessToken)'
+                  -definitionId $(System.DefinitionId)
+                  -ownerId 'User:$(Build.RequestedForId)'
+                  -buildId $(Build.BuildId)
+                  -collectionUri '$(System.CollectionUri)'
+                  -teamProject '$(System.TeamProject)'"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -559,3 +559,11 @@ stages:
                   parameters:
                     ContinueEvenIfResourcesAreGettingDestroyed: ${{ parameters.ContinueEvenIfResourcesAreGettingDestroyed }}
                     AzureSubscription: "File-Share-Service-Live-P4052"
+
+      - job: PostDeploymentActions
+        dependsOn:
+        - LiveDeploy
+        pool: $(WindowPool)
+        displayName: Post Deployment Actions
+        steps:
+          - template: Deployment/templates/retain-pipeline.yml


### PR DESCRIPTION
This change only affects deploy to live. To test I created a new branch off this one, TD/Abzu-69881-TempTest, with a modified azure-pipelines.yml script, to update the build retention period on dev deploy, not live. See results here:
https://dev.azure.com/ukhydro/File%20Share%20Service/_build/results?buildId=141299&view=results