### PR TITLE
Update azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,7 +72,6 @@ stages:
                   Invoke-VulnerabilityCheck -ReportLocation $ReportLocation
 
      - job: BuildTestPublish
-       dependsOn: Dependencychecker
         
        pool: $(DeploymentPool)
        container: ${{variables.Container}}


### PR DESCRIPTION
hotfix to allow dependency checker to be bypassed in case of failing dependency checks