### PR TITLE
Add PBI creation

### DIFF
--- a/.github/workflows/dependabot-work-item.yml
+++ b/.github/workflows/dependabot-work-item.yml
@@ -1,0 +1,18 @@
+name: dependabot-work-item
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  create-work-item:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    uses: UKHO/repo-auto-patch/.github/workflows/create-pr-work-item.yml@v1
+    with:
+      pr-url: ${{ github.event.pull_request.html_url }}
+      work-item-title: "FSS UI - Dependabot update"
+      work-item-description: "Please review PR. Created by the dependabot-work-item action."
+      work-item-tags: "File Share Service; TD2; Technical Debt"
+    secrets:
+      ado-pat: ${{ secrets.ADO_TOKEN }}

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -4,10 +4,14 @@
     <notes>
       <![CDATA[
    file name: vite:4.5.2.  To fix we would need to update to  @angular-devkit/build-angular@17.3.3 which is a breaking change.
+   PBI https://dev.azure.com/ukhydro/Abzu/_workitems/edit/159873
    ]]>
     </notes>
     <packageUrl regex="true">^pkg:npm/vite@.*$</packageUrl>
     <vulnerabilityName>GHSA-8jhw-289h-jh2g</vulnerabilityName>
+    <vulnerabilityName>CVE-2024-31207</vulnerabilityName>
+    <vulnerabilityName>GHSA-64vr-g452-qvp3</vulnerabilityName>
+    <vulnerabilityName>GHSA-9cwx-2883-4wfx</vulnerabilityName>
   </suppress>
   <suppress>
     <notes>
@@ -28,16 +32,6 @@
     <packageUrl regex="true">^pkg:npm/tar@.*$</packageUrl>
     <vulnerabilityName>CVE-2024-28863</vulnerabilityName>
     <cpe>cpe:/a:tar_project:tar</cpe>
-  </suppress>
-  <suppress>
-    <notes>
-      <![CDATA[
-   file name: vite:4.5.2
-   PBI https://dev.azure.com/ukhydro/Abzu/_workitems/edit/159873
-   ]]>
-    </notes>
-    <packageUrl regex="true">^pkg:npm/vite@.*$</packageUrl>
-    <vulnerabilityName>CVE-2024-31207</vulnerabilityName>
   </suppress>
   <suppress>
     <notes>


### PR DESCRIPTION
#### PR Classification
New feature to automate work item creation for Dependabot pull requests.

#### PR Summary
Introduces a GitHub Actions workflow to create work items for Dependabot pull requests.
- `.github/workflows/dependabot-work-item.yml`: Adds a workflow that triggers on pull requests to the `main` branch, creating a work item if the actor is `dependabot[bot]`.
- Utilizes a predefined workflow from `UKHO/repo-auto-patch` and uses the `ADO_TOKEN` secret for authentication.
