### PR TITLE
Update from main 17/10/2024

### DIFF
--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -65,8 +65,8 @@ jobs:
     value: $(essConfig-aioExcludeEncs)
   - name: essConfig.apiUiUrl
     value: $(essConfig-apiUiUrl)
-  - name: essConfig.adminDomains
-    value: $(essConfig-AdminDomains)
+  - name: essConfig.privilegedUserDomains
+    value: $(essConfig-PrivilegedUserDomains)
   strategy:
     runOnce:
       deploy:

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -53,4 +53,15 @@
     <packageUrl regex="true">^pkg:npm/webpack@.*$</packageUrl>
     <cve>CVE-2024-43788</cve>
   </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+   file name: cookie:0.6.0
+   Suppressed until angular upgrade.
+   ]]>
+    </notes>
+    <packageUrl regex="true">^pkg:npm/cookie@.*$</packageUrl>
+    <vulnerabilityName>CVE-2024-47764</vulnerabilityName>
+    <vulnerabilityName>GHSA-pxg6-pf52-xh8x</vulnerabilityName>
+  </suppress>
 </suppressions>

--- a/Tests/UnitTests/fss-header.component.spec.ts
+++ b/Tests/UnitTests/fss-header.component.spec.ts
@@ -105,7 +105,7 @@ describe('FssHeaderComponent', () => {
 
   test('should set isPrivilegedUser to true for admin domains', () => {
     component = new FssHeaderComponent(msalGuardConfiguration, msalService, route, msalBroadcastServie, analyticsService, signInButtonService,essUploadFileService);
-    component.configAdminDomains = ["test.com","abcd.com"];
+    component.configPrivilegedUserDomains = ["test.com","abcd.com"];
     const claims = {
       email: "admin@test.com"
     };

--- a/src/app/shared/components/fss-header/fss-header.component.ts
+++ b/src/app/shared/components/fss-header/fss-header.component.ts
@@ -36,7 +36,7 @@ export class FssHeaderComponent implements OnInit, AfterViewInit, OnDestroy {
   isActive: boolean = false;
   fssSilentTokenRequest: SilentRequest;
   fssTokenScope: any = [];
-  configAdminDomains: string[];
+  configPrivilegedUserDomains: string[];
   constructor(@Inject(MSAL_GUARD_CONFIG) private msalGuardConfig: MsalGuardConfiguration,
     private msalService: MsalService,
     private route: Router,
@@ -46,7 +46,7 @@ export class FssHeaderComponent implements OnInit, AfterViewInit, OnDestroy {
     private essUploadFileService: EssUploadFileService) {
 
     this.fssTokenScope = AppConfigService.settings["fssConfig"].apiScope;
-    this.configAdminDomains = AppConfigService.settings["essConfig"].adminDomains;
+    this.configPrivilegedUserDomains = AppConfigService.settings["essConfig"].privilegedUserDomains;
     this.fssSilentTokenRequest = {
       scopes: [this.fssTokenScope],
     };
@@ -191,8 +191,8 @@ export class FssHeaderComponent implements OnInit, AfterViewInit, OnDestroy {
     this.signedInName = this.userName;
     
     const email = claims ? claims['email'] : null;
-    this.configAdminDomains.forEach(configAdminDomain => {
-      if (email && (email.toLowerCase().endsWith(configAdminDomain.toLowerCase()))) {
+    this.configPrivilegedUserDomains.forEach(configPrivilegedUserDomain => {
+      if (email && (email.toLowerCase().endsWith(configPrivilegedUserDomain.toLowerCase()))) {
         this.essUploadFileService.isPrivilegedUser = true;
       }
     })

--- a/src/assets/config/appconfig.json
+++ b/src/assets/config/appconfig.json
@@ -57,6 +57,6 @@
     "defaultEstimatedSizeinMB": "0.5",
     "aioExcludeEncs": [ "GB800002", "FR800002" ],
     "apiUiUrl": "",
-    "adminDomains":[]
+    "privilegedUserDomains": []
   }
 }


### PR DESCRIPTION
#### PR Classification
Configuration update and vulnerability suppression.

#### PR Summary
Updated configuration keys and added vulnerability suppression.
- `continuous-deployment.yml`: Replaced `essConfig.adminDomains` with `essConfig.privilegedUserDomains`.
- `NVDSuppressions.xml`: Added suppression for `cookie` package version `0.6.0` for `CVE-2024-47764` and `GHSA-pxg6-pf52-xh8x`.
- `fss-header.component.ts` and `fss-header.component.spec.ts`: Renamed `configAdminDomains` to `configPrivilegedUserDomains`.
- `appconfig.json`: Replaced `adminDomains` with `privilegedUserDomains`.
