### PR TITLE
Disable XML transformation in CI/CD pipelines

### DIFF
--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -103,7 +103,7 @@ jobs:
           displayName: File transform - website config
           inputs:
             folderPath: "$(Pipeline.Workspace)/AngularApp/ukho-fileshareservice-ui"
-            xmlTransformationRules:
+            enableXmlTransform: false
             jsonTargetFiles: '**/appconfig.json'
 
         - task: AzureCLI@2

--- a/Deployment/templates/playwright-testing.yml
+++ b/Deployment/templates/playwright-testing.yml
@@ -58,7 +58,7 @@ jobs:
     displayName: AppSetting transform for ${{ parameters.TestDescription }} tests
     inputs:
       folderPath: '$(Build.SourcesDirectory)\'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: appSetting.json
                 
   - script: |


### PR DESCRIPTION
The `FileTransform@2` tasks in both `continuous-deployment.yml` and `playwright-testing.yml` have been updated. Specifically, the `xmlTransformationRules` input has been removed and replaced with `enableXmlTransform: false`. This change indicates that XML transformation rules are no longer being used, and XML transformation is explicitly disabled.