### PR TITLE
Remove AVCS product type filter from configurations

### DIFF
--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -28,4 +28,13 @@
     <packageUrl regex="true">^pkg:npm/vite@.*$</packageUrl>
     <vulnerabilityName>GHSA-vg6x-rcgg-rjx6</vulnerabilityName>
   </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+   file name: esbuild:0.21.5
+   ]]>
+    </notes>
+    <packageUrl regex="true">^pkg:npm/esbuild@.*$</packageUrl>
+    <vulnerabilityName>GHSA-67mh-4wv8-2f99</vulnerabilityName>
+  </suppress>
 </suppressions>

--- a/src/assets/config/popularsearchconfig.json
+++ b/src/assets/config/popularsearchconfig.json
@@ -144,13 +144,6 @@
     "isActive": true,
     "rows": [
       {
-        "field": "$batch(Product Type)",
-        "operator": "eq",
-        "isDynamicValue": false,
-        "value": "AVCS"
-      },
-      {
-        "andOr": "and",
         "field": "$batch(S63 Version)",
         "operator": "eq",
         "isDynamicValue": false,

--- a/src/assets/config/simplepopularsearchconfig.json
+++ b/src/assets/config/simplepopularsearchconfig.json
@@ -144,13 +144,6 @@
     "isActive": true,
     "rows": [
       {
-        "field": "$batch(Product Type)",
-        "operator": "eq",
-        "isDynamicValue": false,
-        "value": "AVCS"
-      },
-      {
-        "andOr": "and",
         "field": "$batch(S63 Version)",
         "operator": "eq",
         "isDynamicValue": false,


### PR DESCRIPTION
Remove AVCS product type filter from configurations

This commit removes the filter condition for "Product Type"
equal to "AVCS" from the "rows" array in the "avcs" section
of both `popularsearchconfig.json` and `simplepopularsearchconfig.json`.
This change may impact how AVCS-related content is filtered
or displayed in the application.